### PR TITLE
:fire: Remove the pod autoscaling reference

### DIFF
--- a/helm/operations-engineering-metadata/templates/deployment.yaml
+++ b/helm/operations-engineering-metadata/templates/deployment.yaml
@@ -5,9 +5,7 @@ metadata:
   labels:
     {{- include "operations-engineering-metadata.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "operations-engineering-metadata.selectorLabels" . | nindent 6 }}

--- a/helm/operations-engineering-metadata/values.yaml
+++ b/helm/operations-engineering-metadata/values.yaml
@@ -59,9 +59,6 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-autoscaling:
-  enabled: false
-
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This connects to ministryofjustice/operations-engineering#3597 and removes the call to create autoscaling pods. This feature was never actually used so didn't appear in Cloud Platform's review. This commit removes the chance of it being created in the future.
